### PR TITLE
Various Fixes

### DIFF
--- a/radio/functions.js
+++ b/radio/functions.js
@@ -81,7 +81,7 @@ $(document).on('click','.glyphicon-remove-sign',function(e){
 //Create New Command
 $("#CreateNew").click(function(e) {
 	e.preventDefault();
-	$('#CustomCommands input').each(function(){
+	$('#CustomCommands [required]').each(function(){
 		$(this).val()==""?$(this).focus().parent().addClass("has-error"):$(this).parent().removeClass("has-error");
 	});
 	if ($('#CustomCommands .has-error').length > 0) {

--- a/radio/functions.js
+++ b/radio/functions.js
@@ -78,6 +78,18 @@ $(document).on('click','.glyphicon-remove-sign',function(e){
 	saveData();
 });
 
+//Format new command
+$("#FormatNew").click(function(e) {
+	e.preventDefault();
+	var cmd = $("#NewCommand").val().replace(/\/\/.*|\"/g,'').replace(/(?:\r\n|\r|\n)/g,";").replace(/\s+/g," ").replace(/;+|\s+;+|;+\s+/g,";");	
+	if (cmd.substring(0,1)===";"){
+		cmd = cmd.substring(1);
+	}
+	if (cmd.substring(--cmd.length)===";"){
+		cmd = cmd.substring(0,--cmd.length);
+	}
+	$("#NewCommand").val(cmd);
+});
 //Create New Command
 $("#CreateNew").click(function(e) {
 	e.preventDefault();

--- a/radio/functions.js
+++ b/radio/functions.js
@@ -88,8 +88,14 @@ $("#CreateNew").click(function(e) {
 		return;
 	}
 	var label = $("#NewLabel").val();
-	var cmd = $("#NewCommand").val();
-
+	var cmd = $("#NewCommand").val().replace(/\/\/.*|\"/g,'').replace(/(?:\r\n|\r|\n)/g,";").replace(/\s+/g," ").replace(/;+|\s+;+|;+\s+/g,";");	
+	if (cmd.substring(0,1)===";"){
+		cmd = cmd.substring(1);
+	}
+	if (cmd.substring(--cmd.length)===";"){
+		cmd = cmd.substring(0,--cmd.length);
+	}
+	
 	var str = '<li class="list-group-item" label="'+label+'" value="'+cmd+'" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="'+cmd.replace(/;/g,";<br>")+'"></span>'+label+'</li>';
 	
 	$("#unusedList").append(str);

--- a/radio/functions.js
+++ b/radio/functions.js
@@ -120,7 +120,7 @@ $("#View").click(function(){
 	delete radios.Unused;
 	post('./view.php?view', {
 		value: JSON.stringify(radios)
-	});
+	},"_BLANK");
 });
 
 //Delete stored data
@@ -131,14 +131,14 @@ $("#Reset").click(function(){
 });
 
 //post data
-function post(path, params, method) {
-    method = method || "post"; // Set method to post by default if not specified.
+function post(path, params, target="", method="post") {
 
     // The rest of this code assumes you are not using a library.
     // It can be made less wordy if you use one.
     var form = document.createElement("form");
     form.setAttribute("method", method);
     form.setAttribute("action", path);
+    form.setAttribute("target", target);
 
     for (var key in params) {
         if (params.hasOwnProperty(key)) {

--- a/radio/index.html
+++ b/radio/index.html
@@ -136,7 +136,8 @@
 					<label for="NewCommand">Command(s):</label>
 					<textarea class="form-control" autocomplete="off" id="NewCommand" placeholder="Command(s)" required></textarea>
 				</div>
-				<button type="submit" id="CreateNew" class="btn btn-primary">Create Command</button>
+				<button type="submit" id="CreateNew" class="btn btn-success">Create Command</button>
+				<button type="submit" id="FormatNew" class="btn btn-primary">Format Command</button>
 			</form>
 					
 			<p>The "label" text box is the label for the entry.<br>
@@ -146,7 +147,8 @@
 			<p>Example: <pre>voice_enable 0</pre></p>
 			
 			<p>Multi-line commands <strong>work!</strong><br>
-			In the command box, enter your commands in this format: <pre>sv_cheats 1;cl_drawhud 0;noclip</pre></p>
+			In the command box, enter your commands in this format: <pre>sv_cheats 1;cl_drawhud 0;noclip</pre> or click the format button and we will do it for you!</p>
+			<p><strong>Do not</strong> enter alias/bind commands which activate multiple actions at once like so: <pre style="color:red">bind "h" "+jump;-attack"</pre> as the quote marks are removed when added, so your command will not execute as intended</p>
 			
 		</div>
 	</div>

--- a/radio/index.html
+++ b/radio/index.html
@@ -157,7 +157,7 @@
 		<div class="modal-content">
 		  <div class="modal-header">
 			<button type="button" class="close" data-dismiss="modal">&times;</button>
-			<h4 class="modal-title">Credits</h4>
+			<h2 class="modal-title">Credits</h2>
 		  </div>
 		  <div class="modal-body">
 			<h3>mcJustWas</h3>

--- a/radio/index.html
+++ b/radio/index.html
@@ -21,111 +21,111 @@
 			</div>
 		</div>
 	</nav>
-<div class="container-fluid">
-    <div id="gen" class="col-md-9 col-sm-12 col-xs-12">
-		<h3>Radio's:</h3>
-		<div class="row">
-			<div class="col-md-3 col-sm-6 col-xs-12">
-				<div id="radio1" class="panel panel-default">
-				  <div class="panel-heading">
-					<span class="panel-title" data-toggle="tooltip" title="Radio Menu Name<br>(click to edit)" contenteditable>Radio 1</span><kbd data-toggle="tooltip" title="Default key to open this menu in game" style="float:right;">Z</kbd>
-				  </div>
-				  <div class="panel-body" >
-					<ul id="radio1List" class="list-group">
-						<li class="list-group-item" label="Go!" value="go" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="go"></span>Go!</li>
+	<div id="content" class="container-fluid">
+		<div id="gen" class="col-md-9 col-sm-12 col-xs-12">
+			<h3>Radio's:</h3>
+			<div class="row">
+				<div class="col-md-3 col-sm-6 col-xs-12">
+					<div id="radio1" class="panel panel-default">
+					  <div class="panel-heading">
+						<span class="panel-title" data-toggle="tooltip" title="Radio Menu Name<br>(click to edit)" contenteditable>Radio 1</span><kbd data-toggle="tooltip" title="Default key to open this menu in game" style="float:right;">Z</kbd>
+					  </div>
+					  <div class="panel-body" >
+						<ul id="radio1List" class="list-group">
+							<li class="list-group-item" label="Go!" value="go" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="go"></span>Go!</li>
 
-						<li class="list-group-item" label="Team, Fall Back!" value="fallback" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="fallback"></span>Team, Fall Back!</li>
+							<li class="list-group-item" label="Team, Fall Back!" value="fallback" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="fallback"></span>Team, Fall Back!</li>
 
-						<li class="list-group-item" label="Stick Together, Team" value="sticktog" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="sticktog"></span>Stick Together, Team</li>
+							<li class="list-group-item" label="Stick Together, Team" value="sticktog" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="sticktog"></span>Stick Together, Team</li>
 
-						<li class="list-group-item" label="Hold This Position!" value="holdpos" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="holdpos"></span>Hold This Position!</li>
+							<li class="list-group-item" label="Hold This Position!" value="holdpos" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="holdpos"></span>Hold This Position!</li>
 
-						<li class="list-group-item" label="Follow Me!" value="followme" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="followme"></span>Follow Me!</li>
-					</ul>
-				  </div>
+							<li class="list-group-item" label="Follow Me!" value="followme" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="followme"></span>Follow Me!</li>
+						</ul>
+					  </div>
+					</div>
+				</div>
+				<div class="col-md-3 col-sm-6 col-xs-12">
+					<div id="radio2" class="panel panel-default">
+					  <div class="panel-heading">
+						<span class="panel-title" data-toggle="tooltip" title="Radio Menu Name<br>(click to edit)" contenteditable>Radio 2</span><kbd data-toggle="tooltip" title="Default key to open this menu in game" style="float:right;" >X</kbd>
+					  </div>
+					  <div class="panel-body" >
+						<ul id="radio2List" class="list-group">
+							<li class="list-group-item" label="Yes" value="roger" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="roger"></span>Yes</li>
+
+							<li class="list-group-item" label="No" value="negative" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="negative"></span>No</li>
+
+							<li class="list-group-item" label="Cheer" value="cheer" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="cheer"></span>Cheer</li>
+
+							<li class="list-group-item" label="Complement" value="compliment" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="compliment"></span>Complement</li>
+
+							<li class="list-group-item" label="Thanks" value="thanks" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="thanks"></span>Thanks</li>
+						</ul>
+					  </div>
+					</div>
+				</div>
+				<div class="col-md-3 col-sm-6 col-xs-12">
+					<div id="radio3" class="panel panel-default">
+					  <div class="panel-heading">
+						<span class="panel-title" data-toggle="tooltip" title="Radio Menu Name<br>(click to edit)" contenteditable>Radio 3</span><kbd data-toggle="tooltip" title="Default key to open this menu in game" style="float:right;" >C</kbd>
+					  </div>
+					  <div class="panel-body" >
+						<ul id="radio3List" class="list-group">
+							<li class="list-group-item" label="Enemy Spotted" value="enemyspot" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="enemyspot"></span>Enemy Spotted</li>
+
+							<li class="list-group-item" label="Need Backup" value="needbackup" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="needbackup"></span>Need Backup</li>
+
+							<li class="list-group-item" label="You Take the Point" value="takepoint" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="takepoint"></span>You Take the Point</li>
+
+							<li class="list-group-item" label="Sector Clear" value="sectorclear" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="sectorclear"></span>Sector Clear</li>
+
+							<li class="list-group-item" label="I'm in Position" value="inposition" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="inposition"></span>I'm in Position</li>
+						</ul>
+					  </div>
+					</div>
+				</div>
+				<div class="col-md-3 col-sm-6 col-xs-12">
+					<div id="unused" class="panel panel-default">
+					  <div class="panel-heading">
+						<span class="panel-title">Unused</span>
+					  </div>
+					  <div class="panel-body" >
+						<ul id="unusedList" class="list-group">
+							<li class="list-group-item" label="Cover Me!" value="coverme" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="coverme"></span>Cover Me!</li>
+
+							<li class="list-group-item" label="Regroup, Team!" value="regroup" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="regroup"></span>Regroup, Team!</li>
+
+							<li class="list-group-item" label="Taking Fire, Need Assistance!" value="takingfire" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="takingfire"></span>Taking Fire, Need Assistance!</li>
+
+							<li class="list-group-item" label="Report In" value="report" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="report"></span>Report In</li>
+
+							<li class="list-group-item" label="She's gonna Blow!" value="getout" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="getout"></span>She's gonna Blow!</li>
+
+							<li class="list-group-item" label="Enemy Down" value="enemydown" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="enemydown"></span>Enemy Down</li>
+
+							<li class="list-group-item" label="Reporting In" value="reportingin" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="reportingin"></span>Reporting In</li>
+						</ul>
+					  </div>
+					</div>
 				</div>
 			</div>
-			<div class="col-md-3 col-sm-6 col-xs-12">
-				<div id="radio2" class="panel panel-default">
-				  <div class="panel-heading">
-					<span class="panel-title" data-toggle="tooltip" title="Radio Menu Name<br>(click to edit)" contenteditable>Radio 2</span><kbd data-toggle="tooltip" title="Default key to open this menu in game" style="float:right;" >X</kbd>
-				  </div>
-				  <div class="panel-body" >
-					<ul id="radio2List" class="list-group">
-						<li class="list-group-item" label="Yes" value="roger" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="roger"></span>Yes</li>
-
-						<li class="list-group-item" label="No" value="negative" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="negative"></span>No</li>
-
-						<li class="list-group-item" label="Cheer" value="cheer" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="cheer"></span>Cheer</li>
-
-						<li class="list-group-item" label="Complement" value="compliment" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="compliment"></span>Complement</li>
-
-						<li class="list-group-item" label="Thanks" value="thanks" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="thanks"></span>Thanks</li>
-					</ul>
-				  </div>
-				</div>
+			<div class="col-md-6 col-sm-12 col-xs-12">
+				<p>Drag and drop items from each box.</p>
+				<p>The items in the unused column will not be included in the radiopanel.txt file.</p>
+				<p>Rename your original "radiopanel.txt" to something else as a backup</p>
+				<p>Place the new radiopanel.txt file in your CS:GO directory:<br>
+				<i><strong>steam folder</strong>/steamapps/common/Counter-Strike Global Offensive/csgo/resource/ui/</i></p>
 			</div>
-			<div class="col-md-3 col-sm-6 col-xs-12">
-				<div id="radio3" class="panel panel-default">
-				  <div class="panel-heading">
-					<span class="panel-title" data-toggle="tooltip" title="Radio Menu Name<br>(click to edit)" contenteditable>Radio 3</span><kbd data-toggle="tooltip" title="Default key to open this menu in game" style="float:right;" >C</kbd>
-				  </div>
-				  <div class="panel-body" >
-					<ul id="radio3List" class="list-group">
-						<li class="list-group-item" label="Enemy Spotted" value="enemyspot" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="enemyspot"></span>Enemy Spotted</li>
-
-						<li class="list-group-item" label="Need Backup" value="needbackup" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="needbackup"></span>Need Backup</li>
-
-						<li class="list-group-item" label="You Take the Point" value="takepoint" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="takepoint"></span>You Take the Point</li>
-
-						<li class="list-group-item" label="Sector Clear" value="sectorclear" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="sectorclear"></span>Sector Clear</li>
-
-						<li class="list-group-item" label="I'm in Position" value="inposition" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="inposition"></span>I'm in Position</li>
-					</ul>
-				  </div>
-				</div>
-			</div>
-			<div class="col-md-3 col-sm-6 col-xs-12">
-				<div id="unused" class="panel panel-default">
-				  <div class="panel-heading">
-					<span class="panel-title">Unused</span>
-				  </div>
-				  <div class="panel-body" >
-					<ul id="unusedList" class="list-group">
-						<li class="list-group-item" label="Cover Me!" value="coverme" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="coverme"></span>Cover Me!</li>
-
-						<li class="list-group-item" label="Regroup, Team!" value="regroup" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="regroup"></span>Regroup, Team!</li>
-
-						<li class="list-group-item" label="Taking Fire, Need Assistance!" value="takingfire" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="takingfire"></span>Taking Fire, Need Assistance!</li>
-
-						<li class="list-group-item" label="Report In" value="report" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="report"></span>Report In</li>
-
-						<li class="list-group-item" label="She's gonna Blow!" value="getout" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="getout"></span>She's gonna Blow!</li>
-
-						<li class="list-group-item" label="Enemy Down" value="enemydown" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="enemydown"></span>Enemy Down</li>
-
-						<li class="list-group-item" label="Reporting In" value="reportingin" draggable="true"><a href=""><span class="glyphicon glyphicon-remove-sign"></span></a><span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" title="reportingin"></span>Reporting In</li>
-					</ul>
-				  </div>
-				</div>
+			<div class="col-md-6 col-sm-12 col-xs-12">
+				<button id="Generate" class="btn btn-success col-md-4">Download <span class="glyphicon glyphicon-download-alt"></span></button>
+				<button id="View" class="btn btn-primary col-md-4">View <span class="glyphicon glyphicon-new-window"></span></button>
+				<button id="Reset" class="btn btn-danger col-md-4">Reset <span class="glyphicon glyphicon-refresh"></span></button>
 			</div>
 		</div>
-		<div class="col-md-6 col-sm-12 col-xs-12">
-			<p>Drag and drop items from each box.</p>
-			<p>The items in the unused column will not be included in the radiopanel.txt file.</p>
-			<p>Rename your original "radiopanel.txt" to something else as a backup</p>
-			<p>Place the new radiopanel.txt file in your CS:GO directory:<br>
-			<i><strong>steam folder</strong>/steamapps/common/Counter-Strike Global Offensive/csgo/resource/ui/</i></p>
-		</div>
-		<div class="col-md-6 col-sm-12 col-xs-12">
-			<button id="Generate" class="btn btn-success col-md-4">Download <span class="glyphicon glyphicon-download-alt"></span></button>
-			<button id="View" class="btn btn-primary col-md-4">View <span class="glyphicon glyphicon-new-window"></span></button>
-			<button id="Reset" class="btn btn-danger col-md-4">Reset <span class="glyphicon glyphicon-refresh"></span></button>
-		</div>
-    </div>
 
 
-    <div id="optionsDiv"  class="col-md-3 col-sm-12 col-xs-12">
+		<div id="optionsDiv"  class="col-md-3 col-sm-12 col-xs-12">
 			<h3>Create Custom Commands</h3>
 			<form id="CustomCommands">
 				<div class="form-group">

--- a/radio/style.css
+++ b/radio/style.css
@@ -9,6 +9,7 @@
 }
 
 body {
+	position:relative;
     background-color: white;
     background-image: url(../extras/background.png);
     background-size: cover;

--- a/radio/style.css
+++ b/radio/style.css
@@ -62,7 +62,16 @@ option {
   -moz-user-select: none;      /* Firefox */
   -ms-user-select: none;       /* IE/Edge */
 }
+#content{
+	padding-bottom:50px;
+}
 #footer {
+	background-color:#333;
+	color:white;
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	left: 0;
 	padding-top:20px;
 	border-top:solid 1px #ccc;
 	text-align:center;


### PR DESCRIPTION
## UI
- Moved Footer to bottom
- View Button opens radiopanel.txt in new tab/window (dependent on browser)
- Check both fields in `New Command` Form not empty (was only checking `input` instead of `textarea`&`input`)
## New Commands
- Check both fields in `New Command` Form not empty (was only checking `input` instead of `textarea`&`input`)
- Remove any `"` characters
- remove `;` character from start or end
- remove any newlines
- remove multiple spaces/tab/; characters

can pretty much turn most configs into 1 command
unless it contains aliases or binds which do multiple functions/actions
### examples:

`bind "h" "+jump;-attack"`
will execute incorrectly as
`bind h +jump;` then `-attack;`

But this:

```
bind "1" "slot1"
bind "2" "slot2"
bind "3" "slot3"
```

will execute correctly as: 
`bind 1 slot1;bind 2 slot2;bind 3 slot3`
